### PR TITLE
Fixed an incorrect example in the changeColumn example

### DIFF
--- a/views/sections/migrations.jade
+++ b/views/sections/migrations.jade
@@ -176,7 +176,7 @@ section#migrations
     h4 changeColumn(tableName, attributeName, dataTypeOrOptions)
     p This method changes the meta data of an attribute. It is possible to change the default value, allowance of null or the data type. Please make sure, that you are completely describing the new data type. Missing information are expected to be defaults.
     pre.prettyprint.linenums
-      | migration.addColumn(
+      | migration.changeColumn(
       |   'nameOfAnExistingTable',
       |   'nameOfAnExistingAttribute',
       |   DataTypes.STRING
@@ -184,7 +184,7 @@ section#migrations
       | &nbsp;
       | // or
       | &nbsp;
-      | migration.addColumn(
+      | migration.changeColumn(
       |   'nameOfAnExistingTable',
       |   'nameOfAnExistingAttribute',
       |   {


### PR DESCRIPTION
It appears that when you copied and pasted from the addColumn example you forgot to change the method name.
