### PR TITLE
add 'native' documention to website

### DIFF
--- a/views/documentation/sections/usage/options.md
+++ b/views/documentation/sections/usage/options.md
@@ -35,6 +35,11 @@ var sequelize = new Sequelize('database', 'username', 'password', {
   // - default: false
   omitNull: true,
 
+  // a flag for using a native library or not.
+  // in the case of 'pg' -- set this to true will allow SSL support
+  // - default: false
+  native: true,
+
   // Specify options, which are used when sequelize.define is called.
   // The following example:
   //   define: {timestamps: false}


### PR DESCRIPTION
Needed SSL support for PG.

This line in the connection manager appears to be undocumented

```
this.pg             = this.config.native ? require(pgModule).native : require(pgModule)
```

Which is suggested to allow ssl support by this thread:
https://github.com/brianc/node-postgres/issues/25

And appears to work.

So here is documentation for the next person.
