### PR TITLE
Mention the next argument in custom validation documentation

### DIFF
--- a/views/documentation/sections/models/validations.md
+++ b/views/documentation/sections/models/validations.md
@@ -43,11 +43,15 @@ var ValidateMe = sequelize.define('Foo', {
       isCreditCard: true,       // check for valid credit card numbers
 
       // custom validations are also possible:
-      isEven: function(value) {
-        if(parseInt(value) % 2 != 0) {
-          throw new Error('Only even values are allowed!')
-        // we also are in the model's context here, so this.otherField
+      isEven: function(value, next) {
+        // we are in the model's context here, so this.otherField
         // would get the value of otherField if it existed
+        if(parseInt(value) % 2 != 0) {
+          // Call next with an error message if validation failed
+          next('Only even values are allowed!')
+        } else {
+          // Call next without arguments if validation was successful
+          next()
         }
       }
     }


### PR DESCRIPTION
The current documentation on custom validation functions is outdated. It is impossible to create working validation functions based on it.

This patch mentions the next argument passed to validation functions that allows for asynchronous validation.

It might also fix: https://github.com/sequelize/sequelize-doc/issues/66
