### PR TITLE
Getter could use a good code sample referencing "this"

### DIFF
--- a/views/documentation/sections/models/getters_setters.md
+++ b/views/documentation/sections/models/getters_setters.md
@@ -22,7 +22,7 @@ var Foo = sequelize.define('Foo', {
         do your magic here and return something!
         'this' allows you to access attributes of the model.
 
-        example: this.name works
+        example: this.getDataValue('name') works
       */
     },
     set      : function(v) { /* don't forget to add emphasis! :D */ this.setDataValue('title', v + '!') }


### PR DESCRIPTION
Most getters are probably going to be based on attributes of the model. Sample code is useful to explain that 'this' is available.
