### PR TITLE
Fix code fallback to be monospace. Fix space in font url

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -2,7 +2,7 @@
 @import "bootstrap-theme.min.css";
 @import "ir_black.css";
 @import url("http://fonts.googleapis.com/css?family=Ubuntu:400,700");
-@import url("http://fonts.googleapis.com/css?family=UbuntuMono");
+@import url("http://fonts.googleapis.com/css?family=Ubuntu%20Mono");
 body .navbar .navbar-brand span {
   font-size: 35px;
   position: relative;
@@ -142,7 +142,7 @@ body pre {
 body pre code {
   margin: 0 40px 40px 40px;
   background: transparent;
-  font-family: 'Ubuntu Mono', sans-serif;
+  font-family: 'Ubuntu Mono', monospace;
   font-size: 18px;
 }
 body section .jumbotron {

--- a/public/stylesheets/style.styl
+++ b/public/stylesheets/style.styl
@@ -2,7 +2,7 @@
 @import "bootstrap-theme.min.css"
 @import "ir_black.css"
 @import url(http://fonts.googleapis.com/css?family=Ubuntu:400,700)
-@import url(http://fonts.googleapis.com/css?family=Ubuntu+Mono)
+@import url(http://fonts.googleapis.com/css?family=Ubuntu%20Mono)
 
 @import '_header'
 @import '_footer'
@@ -43,7 +43,7 @@ body {
     code {
       margin: 0 40px 40px 40px
       background:transparent;
-      font-family: 'Ubuntu Mono', sans-serif;
+      font-family: 'Ubuntu Mono', monospace;
       font-size: 18px;
     }
   }


### PR DESCRIPTION
Fixed the fallback for code to be monospace rather than sans-serif. Also switched the space in the font url to be %20, rather than +, since the + was getting stripped by stylus.
