### PR TITLE
Fixed margin causing horizontal scrollbar to show on rowdoc

### DIFF
--- a/public/stylesheets/_dimensions.styl
+++ b/public/stylesheets/_dimensions.styl
@@ -3,6 +3,7 @@
 
   .documentation {
     min-height: 100%
+    margin: 0
 
     & > * {
       min-height: 100%

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -105,6 +105,7 @@ body .navbar ul.nav.navbar-nav li.active a {
 }
 .container-liquid .documentation {
   min-height: 100%;
+  margin: 0;
 }
 .container-liquid .documentation > * {
   min-height: 100%;


### PR DESCRIPTION
The margin on .row was causing the horizontal scrollbar to show on any page with .row .documentation, just added margin:0 fixing the issue. I don't see my change altering anything on the site.
