### PR TITLE
Added more monospace fallback fonts, ordered from nice to ugly

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -179,7 +179,7 @@ body pre {
 body pre code {
   margin: 0 40px 40px 40px;
   background: transparent;
-  font-family: 'Ubuntu Mono', sans-serif;
+  font-family: 'Ubuntu Mono', Consolas, 'Liberation Mono', Courier, monospace;
   font-size: 18px;
 }
 body section .jumbotron {

--- a/public/stylesheets/style.styl
+++ b/public/stylesheets/style.styl
@@ -46,7 +46,7 @@ body {
     code {
       margin: 0 40px 40px 40px
       background:transparent;
-      font-family: 'Ubuntu Mono', sans-serif;
+      font-family: 'Ubuntu Mono', Consolas, 'Liberation Mono', Courier, monospace;
       font-size: 18px;
     }
   }
@@ -76,7 +76,7 @@ body {
       margin: 0
 
       &:first-of-type {
-        margin-top: 92px 
+        margin-top: 92px
       }
 
       > li {


### PR DESCRIPTION
Those are the fonts that GitHub uses as fallback as well.

Also, there was a trailing whitespace... my editor removed that.
