### PR TITLE
Document how to create PKs during createTable

### DIFF
--- a/views/docs/latest/migrations.jade
+++ b/views/docs/latest/migrations.jade
@@ -117,6 +117,17 @@ block documentation
           | migration.createTable(
           |   'nameOfTheNewTable',
           |   {
+          |     id: {
+          |       type: DataTypes.INTEGER,
+          |       primaryKey: true,
+          |       autoIncrement: true
+          |     },
+          |     createdAt: {
+          |       type: DataTypes.DATE
+          |     },
+          |     updatedAt: {
+          |       type: DataTypes.DATE
+          |     },
           |     attr1: DataTypes.STRING,
           |     attr2: DataTypes.INTEGER,
           |     attr3: {


### PR DESCRIPTION
I couldn't find documentation for this before.
Shouldn't "id", "createdAt" and "updatedAt" be a minimal set for creating a new table via a migration task?
