### PR TITLE
added a `raw` button to view source code with no formatting

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -212,6 +212,11 @@ body pre code {
   font-family: 'Ubuntu Mono', Consolas, 'Liberation Mono', Courier, monospace;
   font-size: 18px;
 }
+body pre .view-raw {
+  float: right;
+  padding-right: 10px;
+  cursor: pointer;
+}
 body section .jumbotron {
   background: transparent;
 }

--- a/public/stylesheets/style.styl
+++ b/public/stylesheets/style.styl
@@ -50,6 +50,12 @@ body {
       font-family: 'Ubuntu Mono', Consolas, 'Liberation Mono', Courier, monospace;
       font-size: 18px;
     }
+
+    .view-raw {
+      float: right;
+      padding-right: 10px;
+      cursor: pointer;
+    }
   }
 
   section {

--- a/views/layouts/main.jade
+++ b/views/layouts/main.jade
@@ -91,6 +91,17 @@ html
           )
         })
 
+         $("code[class='javascript']").each(function(){
+            var $c = $(this);
+            var $a = $('<a/>').addClass('view-raw').text('raw');
+            $a.click(function(){
+              var popup = window.open('', "popup");
+              $(popup.document.body).append($('<pre/>').text($c.text()));
+            });
+
+            $a.insertBefore($c);
+         });
+
 
         var scrollToAnchor = function(anchor) {
           var $element = $('[name="' + anchor + '"],[id="' + anchor + '"]')


### PR DESCRIPTION
- opens up in a new window

![screen shot 2014-03-13 at 10 19 08 am](https://f.cloud.github.com/assets/13985/2404509/c343e1f0-aa3c-11e3-801b-68eed6275936.png)

once clicked a popup/new tab is opened with body looking like;

![screen shot 2014-03-13 at 10 19 43 am](https://f.cloud.github.com/assets/13985/2404512/dc51e3e0-aa3c-11e3-9329-027251688d7c.png)
