### PR TITLE
updated node-validator reference

### DIFF
--- a/views/docs/latest/models.jade
+++ b/views/docs/latest/models.jade
@@ -260,8 +260,8 @@ block documentation
         | model validations have been added&period; They allow you to specify format&sol;content&sol;inheritance validations for each attribute of the model&period; You can perform the validation by calling the
         code validate&lpar;&rpar;
         | method on an instance before saving&period; The validations are implemented by&nbsp;
-        a(href='https://github.com/chriso/node-validator', rel='nofollow', target='_blank') node-validator
-        | &comma; and we are currently using v&period; 1&period;1&period;1&period;
+        a(href='https://github.com/chriso/validator.js', rel='nofollow', target='_blank') validator
+        | &comma; and we are currently using v&period; 3&period;2&period;x&period;
       p
         strong Note&colon;&nbsp;
         | In


### PR DESCRIPTION
According to package.json you are using validator (formerly node-validator) version `~3.2.0`.
Updating this allows people to take a look at validator documentation directly without having to go to look in your package.json :)

Do you confirm that? Can we use all the validations provided by validator? If yes I'm going to add more examples to the docs :9
