### PR TITLE
Only throw the first error on syncing the whole database.

### DIFF
--- a/views/articles/express.jade
+++ b/views/articles/express.jade
@@ -92,7 +92,7 @@ block documentation
           |   .sync({ force: true })
           |   .complete(function(err) {
           |     if (err) {
-          |       throw err
+          |       throw err[0]
           |     } else {
           |       http.createServer(app).listen(app.get('port'), function(){
           |         console.log('Express server listening on port ' + app.get('port'))

--- a/views/articles/heroku.jade
+++ b/views/articles/heroku.jade
@@ -183,7 +183,7 @@ block documentation
           | &nbsp;
           | db.sequelize.sync().complete(function(err) {
           |   if (err) {
-          |     throw err
+          |     throw err[0]
           |   } else {
           |     http.createServer(app).listen(app.get('port'), function(){
           |       console.log('Express server listening on port ' + app.get('port'))


### PR DESCRIPTION
When syncing the whole database, we get a list of errors in case of
failure. Throwing a list makes it difficult for other middlewares to
handle the error. Therefore, we throw only the first error.
