### PR TITLE
Removing "isArray" from the list of model validation options

### DIFF
--- a/views/docs/.1.7.0-beta.1/models.jade
+++ b/views/docs/.1.7.0-beta.1/models.jade
@@ -303,7 +303,6 @@ block documentation
           |       isBefore: "2011-11-05",   // only allow date strings before a specific date
           |       max: 23,                  // only allow values <= 23
           |       min: 23,                  // only allow values >= 23
-          |       isArray: true,            // only allow arrays
           |       isCreditCard: true,       // check for valid credit card numbers
           | &nbsp;
           |       // custom validations are also possible:

--- a/views/docs/.1.7.6/models.jade
+++ b/views/docs/.1.7.6/models.jade
@@ -310,7 +310,6 @@ block documentation
           |       isBefore: "2011-11-05",   // only allow date strings before a specific date
           |       max: 23,                  // only allow values <= 23
           |       min: 23,                  // only allow values >= 23
-          |       isArray: true,            // only allow arrays
           |       isCreditCard: true,       // check for valid credit card numbers
           | &nbsp;
           |       // custom validations are also possible:

--- a/views/docs/.1.7.8/models.jade
+++ b/views/docs/.1.7.8/models.jade
@@ -310,7 +310,6 @@ block documentation
           |       isBefore: "2011-11-05",   // only allow date strings before a specific date
           |       max: 23,                  // only allow values <= 23
           |       min: 23,                  // only allow values >= 23
-          |       isArray: true,            // only allow arrays
           |       isCreditCard: true,       // check for valid credit card numbers
           | &nbsp;
           |       // custom validations are also possible:

--- a/views/docs/latest/models.jade
+++ b/views/docs/latest/models.jade
@@ -314,7 +314,6 @@ block documentation
           |       isBefore: "2011-11-05",   // only allow date strings before a specific date
           |       max: 23,                  // only allow values <= 23
           |       min: 23,                  // only allow values >= 23
-          |       isArray: true,            // only allow arrays
           |       isCreditCard: true,       // check for valid credit card numbers
           | &nbsp;
           |       // custom validations are also possible:


### PR DESCRIPTION
The isArray validator does not appear to actually exist as a valid option (it fails during usage and I can't find it in the library but please correct me if I'm wrong!) Updating the documentation to reflect this.
